### PR TITLE
feat: enable Load State button based on total saved projects count

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,9 +8,24 @@
     "dev": "nodemon",
     "build": "tsc",
     "lint": "eslint src --ext .ts",
-    "test": "jest"
+    "test": "jest",
+    "migration:create": "mikro-orm migration:create",
+    "migration:up": "mikro-orm migration:up",
+    "migration:down": "mikro-orm migration:down",
+    "schema:fresh": "mikro-orm schema:fresh --run",
+    "schema:update": "mikro-orm schema:update --run"
+  },
+  "mikro-orm": {
+    "useTsNode": true,
+    "configPaths": [
+      "./src/mikro-orm.config.ts"
+    ]
   },
   "dependencies": {
+    "@mikro-orm/cli": "^6.4.0",
+    "@mikro-orm/core": "^6.4.0",
+    "@mikro-orm/migrations": "^6.4.0",
+    "@mikro-orm/sqlite": "^6.4.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/sqlite3": "^3.1.11",
     "@types/swagger-jsdoc": "^6.0.4",

--- a/apps/backend/src/entities/ChatMessage.ts
+++ b/apps/backend/src/entities/ChatMessage.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryKey, Property, ManyToOne } from '@mikro-orm/core';
+import { Project } from './Project';
+
+@Entity()
+export class ChatMessage {
+  @PrimaryKey({ autoincrement: true })
+  id!: number;
+
+  @ManyToOne(() => Project)
+  project!: Project;
+
+  @Property()
+  role!: string;
+
+  @Property()
+  content!: string;
+
+  @Property()
+  timestamp: Date = new Date();
+}

--- a/apps/backend/src/entities/Project.ts
+++ b/apps/backend/src/entities/Project.ts
@@ -1,0 +1,33 @@
+import { Entity, PrimaryKey, Property, Collection, OneToMany } from '@mikro-orm/core';
+import { ChatMessage } from './ChatMessage';
+import { ProjectSave } from './ProjectSave';
+
+@Entity()
+export class Project {
+  @PrimaryKey()
+  id!: string;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  path!: string;
+
+  @Property({ nullable: true })
+  description?: string;
+
+  @Property({ nullable: true, fieldName: 'git_repo' })
+  gitRepo?: string;
+
+  @Property({ fieldName: 'created_at' })
+  createdAt: Date = new Date();
+
+  @Property({ fieldName: 'updated_at', onUpdate: () => new Date() })
+  updatedAt: Date = new Date();
+
+  @OneToMany(() => ChatMessage, message => message.project)
+  messages = new Collection<ChatMessage>(this);
+
+  @OneToMany(() => ProjectSave, save => save.project)
+  saves = new Collection<ProjectSave>(this);
+}

--- a/apps/backend/src/entities/ProjectSave.ts
+++ b/apps/backend/src/entities/ProjectSave.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryKey, Property, ManyToOne } from '@mikro-orm/core';
+import { Project } from './Project';
+
+@Entity()
+export class ProjectSave {
+  @PrimaryKey({ autoincrement: true })
+  id!: number;
+
+  @ManyToOne(() => Project)
+  project!: Project;
+
+  @Property()
+  name!: string;
+
+  @Property({ type: 'json' })
+  data!: string;
+
+  @Property({ fieldName: 'created_at' })
+  createdAt: Date = new Date();
+}

--- a/apps/backend/src/entities/ProjectSave.ts
+++ b/apps/backend/src/entities/ProjectSave.ts
@@ -12,7 +12,7 @@ export class ProjectSave {
   @Property()
   name!: string;
 
-  @Property({ type: 'json' })
+  @Property({ type: 'text' })
   data!: string;
 
   @Property({ fieldName: 'created_at' })

--- a/apps/backend/src/entities/index.ts
+++ b/apps/backend/src/entities/index.ts
@@ -1,0 +1,3 @@
+export * from './Project';
+export * from './ChatMessage';
+export * from './ProjectSave';

--- a/apps/backend/src/migrations/.snapshot-neuroforge.db.json
+++ b/apps/backend/src/migrations/.snapshot-neuroforge.db.json
@@ -218,13 +218,13 @@
         },
         "data": {
           "name": "data",
-          "type": "json",
+          "type": "text",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "length": null,
-          "mappedType": "json"
+          "mappedType": "text"
         },
         "created_at": {
           "name": "created_at",

--- a/apps/backend/src/migrations/.snapshot-neuroforge.db.json
+++ b/apps/backend/src/migrations/.snapshot-neuroforge.db.json
@@ -1,0 +1,282 @@
+{
+  "namespaces": [],
+  "tables": [
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "text"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "text"
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "text"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": null,
+          "mappedType": "text"
+        },
+        "git_repo": {
+          "name": "git_repo",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": null,
+          "mappedType": "text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "datetime"
+        }
+      },
+      "name": "project",
+      "indexes": [
+        {
+          "keyName": "primary",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "unsigned": false,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "length": null,
+          "mappedType": "integer"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "text"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "text"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "text"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "datetime"
+        }
+      },
+      "name": "chat_message",
+      "indexes": [
+        {
+          "columnNames": [
+            "project_id"
+          ],
+          "composite": false,
+          "keyName": "chat_message_project_id_index",
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "primary",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "chat_message_project_id_foreign": {
+          "constraintName": "chat_message_project_id_foreign",
+          "columnNames": [
+            "project_id"
+          ],
+          "localTableName": "chat_message",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "project",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "unsigned": false,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "length": null,
+          "mappedType": "integer"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "text"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "text"
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "datetime"
+        }
+      },
+      "name": "project_save",
+      "indexes": [
+        {
+          "columnNames": [
+            "project_id"
+          ],
+          "composite": false,
+          "keyName": "project_save_project_id_index",
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "primary",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "project_save_project_id_foreign": {
+          "constraintName": "project_save_project_id_foreign",
+          "columnNames": [
+            "project_id"
+          ],
+          "localTableName": "project_save",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "project",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    }
+  ],
+  "nativeEnums": {}
+}

--- a/apps/backend/src/migrations/Migration20241205135924.ts
+++ b/apps/backend/src/migrations/Migration20241205135924.ts
@@ -3,19 +3,27 @@ import { Migration } from '@mikro-orm/migrations';
 export class Migration20241205135924 extends Migration {
 
   override async up(): Promise<void> {
-    this.addSql(`create table \`project\` (\`id\` text not null, \`name\` text not null, \`path\` text not null, \`description\` text null, \`git_repo\` text null, \`created_at\` datetime not null, \`updated_at\` datetime not null, primary key (\`id\`));`);
+    // Drop existing tables first
+    this.addSql('drop table if exists `chat_messages`;');
+    this.addSql('drop table if exists `project_saves`;');
+    this.addSql('drop table if exists `projects`;');
+    this.addSql('drop table if exists `project`;');
+    this.addSql('drop table if exists `chat_message`;');
+    this.addSql('drop table if exists `project_save`;');
 
-    this.addSql(`create table \`chat_message\` (\`id\` integer not null primary key autoincrement, \`project_id\` text not null, \`role\` text not null, \`content\` text not null, \`timestamp\` datetime not null, constraint \`chat_message_project_id_foreign\` foreign key(\`project_id\`) references \`project\`(\`id\`) on update cascade);`);
-    this.addSql(`create index \`chat_message_project_id_index\` on \`chat_message\` (\`project_id\`);`);
+    // Create new tables
+    this.addSql('create table `project` (`id` text not null, `name` text not null, `path` text not null, `description` text null, `git_repo` text null, `created_at` datetime not null, `updated_at` datetime not null, primary key (`id`));');
 
-    this.addSql(`create table \`project_save\` (\`id\` integer not null primary key autoincrement, \`project_id\` text not null, \`name\` text not null, \`data\` json not null, \`created_at\` datetime not null, constraint \`project_save_project_id_foreign\` foreign key(\`project_id\`) references \`project\`(\`id\`) on update cascade);`);
-    this.addSql(`create index \`project_save_project_id_index\` on \`project_save\` (\`project_id\`);`);
+    this.addSql('create table `chat_message` (`id` integer not null primary key autoincrement, `project_id` text not null, `role` text not null, `content` text not null, `timestamp` datetime not null, constraint `chat_message_project_id_foreign` foreign key(`project_id`) references `project`(`id`) on update cascade);');
+    this.addSql('create index `chat_message_project_id_index` on `chat_message` (`project_id`);');
 
-    this.addSql(`drop table if exists \`chat_messages\`;`);
-
-    this.addSql(`drop table if exists \`project_saves\`;`);
-
-    this.addSql(`drop table if exists \`projects\`;`);
+    this.addSql('create table `project_save` (`id` integer not null primary key autoincrement, `project_id` text not null, `name` text not null, `data` json not null, `created_at` datetime not null, constraint `project_save_project_id_foreign` foreign key(`project_id`) references `project`(`id`) on update cascade);');
+    this.addSql('create index `project_save_project_id_index` on `project_save` (`project_id`);');
   }
 
+  override async down(): Promise<void> {
+    this.addSql('drop table if exists `chat_message`;');
+    this.addSql('drop table if exists `project_save`;');
+    this.addSql('drop table if exists `project`;');
+  }
 }

--- a/apps/backend/src/migrations/Migration20241205135924.ts
+++ b/apps/backend/src/migrations/Migration20241205135924.ts
@@ -1,0 +1,21 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20241205135924 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table \`project\` (\`id\` text not null, \`name\` text not null, \`path\` text not null, \`description\` text null, \`git_repo\` text null, \`created_at\` datetime not null, \`updated_at\` datetime not null, primary key (\`id\`));`);
+
+    this.addSql(`create table \`chat_message\` (\`id\` integer not null primary key autoincrement, \`project_id\` text not null, \`role\` text not null, \`content\` text not null, \`timestamp\` datetime not null, constraint \`chat_message_project_id_foreign\` foreign key(\`project_id\`) references \`project\`(\`id\`) on update cascade);`);
+    this.addSql(`create index \`chat_message_project_id_index\` on \`chat_message\` (\`project_id\`);`);
+
+    this.addSql(`create table \`project_save\` (\`id\` integer not null primary key autoincrement, \`project_id\` text not null, \`name\` text not null, \`data\` json not null, \`created_at\` datetime not null, constraint \`project_save_project_id_foreign\` foreign key(\`project_id\`) references \`project\`(\`id\`) on update cascade);`);
+    this.addSql(`create index \`project_save_project_id_index\` on \`project_save\` (\`project_id\`);`);
+
+    this.addSql(`drop table if exists \`chat_messages\`;`);
+
+    this.addSql(`drop table if exists \`project_saves\`;`);
+
+    this.addSql(`drop table if exists \`projects\`;`);
+  }
+
+}

--- a/apps/backend/src/migrations/Migration20241205143612.ts
+++ b/apps/backend/src/migrations/Migration20241205143612.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20241205143612 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`pragma foreign_keys = off;`);
+    this.addSql(`create table \`project_save__temp_alter\` (\`id\` integer not null primary key autoincrement, \`project_id\` text not null, \`name\` text not null, \`data\` text not null, \`created_at\` datetime not null, constraint \`project_save_project_id_foreign\` foreign key(\`project_id\`) references \`project\`(\`id\`) on update cascade);`);
+    this.addSql(`insert into \`project_save__temp_alter\` select * from \`project_save\`;`);
+    this.addSql(`drop table \`project_save\`;`);
+    this.addSql(`alter table \`project_save__temp_alter\` rename to \`project_save\`;`);
+    this.addSql(`create index \`project_save_project_id_index\` on \`project_save\` (\`project_id\`);`);
+    this.addSql(`pragma foreign_keys = on;`);
+  }
+
+}

--- a/apps/backend/src/mikro-orm.config.ts
+++ b/apps/backend/src/mikro-orm.config.ts
@@ -1,0 +1,21 @@
+import { Options } from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import path from 'path';
+import { Project, ChatMessage, ProjectSave } from './entities';
+
+const config: Options = {
+  driver: SqliteDriver,
+  dbName: path.join(process.cwd(), 'db', 'neuroforge.db'),
+  entities: [Project, ChatMessage, ProjectSave],
+  migrations: {
+    path: path.join(process.cwd(), 'dist', 'migrations'),
+    pathTs: path.join(process.cwd(), 'src', 'migrations'),
+  },
+  seeder: {
+    path: path.join(process.cwd(), 'dist', 'seeders'),
+    pathTs: path.join(process.cwd(), 'src', 'seeders'),
+  },
+  debug: process.env.NODE_ENV !== 'production',
+};
+
+export default config;

--- a/apps/backend/src/routes/project.ts
+++ b/apps/backend/src/routes/project.ts
@@ -1,10 +1,29 @@
-import express from 'express';
+import express, { Router } from 'express';
 import { projectService } from '../services/ProjectService';
 import { AIArchitectService } from '../services/AIArchitect';
 import { dbService } from '../services/DatabaseService';
 
-const router = express.Router();
+const router: Router = express.Router();
 const aiArchitect = new AIArchitectService();
+
+/**
+ * @swagger
+ * /api/projects/saves/count:
+ *   get:
+ *     summary: Get total number of saved projects
+ *     responses:
+ *       200:
+ *         description: Total number of saved projects
+ */
+router.get('/saves/count', async (req, res) => {
+    try {
+        const count = await projectService.getTotalSavedProjects();
+        res.json({ count });
+    } catch (error) {
+        console.error('Failed to get total saved projects:', error);
+        res.status(500).json({ error: 'Failed to get total saved projects' });
+    }
+});
 
 /**
  * @swagger

--- a/apps/backend/src/services/AIArchitect.ts
+++ b/apps/backend/src/services/AIArchitect.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import OpenAI from 'openai';
-import { ChatCompletionMessageParam, ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam, ChatCompletionAssistantMessageParam } from 'openai/resources/chat';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 
 interface ChatMessage {
   role: 'user' | 'assistant';
@@ -82,14 +82,14 @@ Please provide your response in valid JSON format with the following structure:
 
       // Prepare messages for OpenAI
       const openAiMessages: ChatCompletionMessageParam[] = [
-        { role: "system", content: systemPrompt + "\n" + jsonInstructions } as ChatCompletionSystemMessageParam,
-        ...messages.map(msg => {
-          if (msg.role === 'assistant') {
-            return { role: 'assistant', content: msg.content } as ChatCompletionAssistantMessageParam;
-          } else {
-            return { role: 'user', content: msg.content } as ChatCompletionUserMessageParam;
-          }
-        })
+        {
+          role: "system",
+          content: systemPrompt + "\n" + jsonInstructions
+        },
+        ...messages.map(msg => ({
+          role: msg.role,
+          content: msg.content
+        }))
       ];
 
       console.log('Sending messages to OpenAI:', openAiMessages);
@@ -144,11 +144,11 @@ Please provide your response in valid JSON format with the following structure:
           {
             role: "system",
             content: "You are an AI system prompt generator. Your task is to create a detailed system prompt based on the project description provided."
-          } as ChatCompletionSystemMessageParam,
+          },
           {
             role: "user",
             content: `Generate a system prompt for this project: ${description}`
-          } as ChatCompletionUserMessageParam
+          }
         ],
         temperature: 0.7,
         max_tokens: 1000

--- a/apps/backend/src/services/DatabaseService.ts
+++ b/apps/backend/src/services/DatabaseService.ts
@@ -1,123 +1,67 @@
-import sqlite3 from 'sqlite3';
-import path from 'path';
-import fs from 'fs/promises';
-import { ProjectWithDetails, DatabaseRow, ChatMessage, ProjectSave } from '../types/project';
-
-interface Database {
-    run(sql: string, params?: unknown[]): Promise<void>;
-    get(sql: string, params?: unknown[]): Promise<DatabaseRow>;
-    all(sql: string, params?: unknown[]): Promise<DatabaseRow[]>;
-    exec(sql: string): Promise<void>;
-}
+import { EntityManager, MikroORM } from '@mikro-orm/core';
+import { Project, ChatMessage, ProjectSave } from '../entities';
+import config from '../mikro-orm.config';
+import { ProjectWithDetails } from '../types/project';
 
 class DatabaseService {
-    private db: Database | null = null;
+    private orm: MikroORM | null = null;
+    private em: EntityManager | null = null;
 
     async initialize() {
-        if (this.db) {
+        if (this.orm) {
             return;
         }
 
-        // Create db directory if it doesn't exist
-        const dbDir = path.join(process.cwd(), 'db');
-        await fs.mkdir(dbDir, { recursive: true });
+        try {
+            this.orm = await MikroORM.init(config);
+            this.em = this.orm.em.fork();
 
-        // Initialize database
-        this.db = await this.openDatabase(path.join(dbDir, 'neuroforge.db'));
+            // Run migrations
+            const migrator = this.orm.getMigrator();
+            await migrator.up();
 
-        // Enable foreign keys
-        await this.db.run('PRAGMA foreign_keys = ON');
-
-        // Load and execute schema
-        const schema = await fs.readFile(path.join(process.cwd(), 'src', 'db', 'schema.sql'), 'utf-8');
-        await this.db.exec(schema);
-
-        console.log('Database initialized successfully');
-    }
-
-    private openDatabase(filename: string): Promise<Database> {
-        return new Promise((resolve, reject) => {
-            const db = new sqlite3.Database(filename, (err) => {
-                if (err) {
-                    reject(err);
-                    return;
-                }
-
-                // Wrap database methods in promises
-                const wrappedDb: Database = {
-                    run: (sql: string, params: unknown[] = []) => {
-                        return new Promise((resolve, reject) => {
-                            db.run(sql, params, (err) => {
-                                if (err) reject(err);
-                                else resolve();
-                            });
-                        });
-                    },
-                    get: (sql: string, params: unknown[] = []) => {
-                        return new Promise((resolve, reject) => {
-                            db.get(sql, params, (err, row) => {
-                                if (err) reject(err);
-                                else resolve(row as DatabaseRow);
-                            });
-                        });
-                    },
-                    all: (sql: string, params: unknown[] = []) => {
-                        return new Promise((resolve, reject) => {
-                            db.all(sql, params, (err, rows) => {
-                                if (err) reject(err);
-                                else resolve(rows as DatabaseRow[]);
-                            });
-                        });
-                    },
-                    exec: (sql: string) => {
-                        return new Promise((resolve, reject) => {
-                            db.exec(sql, (err) => {
-                                if (err) reject(err);
-                                else resolve();
-                            });
-                        });
-                    }
-                };
-
-                resolve(wrappedDb);
-            });
-        });
+            console.log('Database initialized successfully');
+        } catch (error) {
+            console.error('Failed to initialize database:', error);
+            throw error;
+        }
     }
 
     async createProject(id: string, name: string, projectPath: string, description?: string, gitRepo?: string) {
-        if (!this.db) {
+        if (!this.em) {
             throw new Error('Database not initialized');
         }
 
-        await this.db.run(
-            'INSERT INTO projects (id, name, path, description, git_repo) VALUES (?, ?, ?, ?, ?)',
-            [id, name, projectPath, description || null, gitRepo || null]
-        );
+        const project = new Project();
+        project.id = id;
+        project.name = name;
+        project.path = projectPath;
+        project.description = description;
+        project.gitRepo = gitRepo;
+
+        await this.em.persistAndFlush(project);
     }
 
     async getProjectDetails(projectId: string): Promise<ProjectWithDetails | null> {
-        if (!this.db) {
+        if (!this.em) {
             throw new Error('Database not initialized');
         }
 
-        const project = await this.db.get(
-            'SELECT * FROM projects WHERE id = ?',
-            [projectId]
-        );
+        const project = await this.em.findOne(Project, { id: projectId });
 
         if (!project) {
             return null;
         }
 
         return {
-            id: project.id as string,
-            name: project.name as string,
-            path: project.path as string,
-            description: project.description as string | null,
-            git_repo: project.git_repo as string | null,
+            id: project.id,
+            name: project.name,
+            path: project.path,
+            description: project.description,
+            git_repo: project.gitRepo,
             details: {
-                name: project.name as string,
-                description: project.description as string | null,
+                name: project.name,
+                description: project.description,
                 stack: null,
                 status: {
                     name: 'incomplete',
@@ -129,122 +73,122 @@ class DatabaseService {
     }
 
     async updateProjectDetails(projectId: string, updates: Partial<ProjectWithDetails>) {
-        if (!this.db) {
+        if (!this.em) {
             throw new Error('Database not initialized');
         }
 
-        const setClauses: string[] = [];
-        const values: unknown[] = [];
+        const project = await this.em.findOne(Project, { id: projectId });
+        if (!project) {
+            throw new Error('Project not found');
+        }
 
         if (updates.name !== undefined) {
-            setClauses.push('name = ?');
-            values.push(updates.name);
+            project.name = updates.name;
         }
         if (updates.description !== undefined) {
-            setClauses.push('description = ?');
-            values.push(updates.description);
+            project.description = updates.description;
         }
         if (updates.git_repo !== undefined) {
-            setClauses.push('git_repo = ?');
-            values.push(updates.git_repo);
+            project.gitRepo = updates.git_repo;
         }
 
-        if (setClauses.length === 0) {
-            return;
-        }
-
-        values.push(projectId);
-
-        await this.db.run(
-            `UPDATE projects SET ${setClauses.join(', ')} WHERE id = ?`,
-            values
-        );
+        await this.em.flush();
     }
 
     async deleteProject(projectId: string) {
-        if (!this.db) {
+        if (!this.em) {
             throw new Error('Database not initialized');
         }
 
-        // First delete related records
-        await this.db.run('DELETE FROM chat_messages WHERE project_id = ?', [projectId]);
-        await this.db.run('DELETE FROM project_saves WHERE project_id = ?', [projectId]);
-
-        // Then delete the project
-        await this.db.run('DELETE FROM projects WHERE id = ?', [projectId]);
+        const project = await this.em.findOne(Project, { id: projectId });
+        if (project) {
+            await this.em.removeAndFlush(project);
+        }
     }
 
     async saveChatMessage(projectId: string, role: string, content: string) {
-        if (!this.db) {
+        if (!this.em) {
             throw new Error('Database not initialized');
         }
 
-        await this.db.run(
-            'INSERT INTO chat_messages (project_id, role, content) VALUES (?, ?, ?)',
-            [projectId, role, content]
-        );
+        const project = await this.em.findOne(Project, { id: projectId });
+        if (!project) {
+            throw new Error('Project not found');
+        }
+
+        const message = new ChatMessage();
+        message.project = project;
+        message.role = role;
+        message.content = content;
+
+        await this.em.persistAndFlush(message);
     }
 
-    async getChatMessages(projectId: string): Promise<ChatMessage[]> {
-        if (!this.db) {
+    async getChatMessages(projectId: string) {
+        if (!this.em) {
             throw new Error('Database not initialized');
         }
 
-        const messages = await this.db.all(
-            'SELECT * FROM chat_messages WHERE project_id = ? ORDER BY timestamp ASC',
-            [projectId]
-        );
+        const messages = await this.em.find(ChatMessage, { project: projectId }, {
+            orderBy: { timestamp: 'ASC' }
+        });
 
         return messages.map(msg => ({
-            role: msg.role as string,
-            content: msg.content as string,
-            timestamp: new Date(msg.timestamp as string)
+            role: msg.role,
+            content: msg.content,
+            timestamp: msg.timestamp
         }));
     }
 
     async clearChatHistory(projectId: string) {
-        if (!this.db) {
+        if (!this.em) {
             throw new Error('Database not initialized');
         }
 
-        await this.db.run('DELETE FROM chat_messages WHERE project_id = ?', [projectId]);
+        await this.em.nativeDelete(ChatMessage, { project: projectId });
     }
 
     async saveProjectState(projectId: string, name: string, data: string) {
-        if (!this.db) {
+        if (!this.em) {
             throw new Error('Database not initialized');
         }
 
-        await this.db.run(
-            'INSERT INTO project_saves (project_id, name, data) VALUES (?, ?, ?)',
-            [projectId, name, data]
-        );
+        const project = await this.em.findOne(Project, { id: projectId });
+        if (!project) {
+            throw new Error('Project not found');
+        }
+
+        const save = new ProjectSave();
+        save.project = project;
+        save.name = name;
+        save.data = data;
+
+        await this.em.persistAndFlush(save);
     }
 
     async loadProjectState(projectId: string, name: string): Promise<string | null> {
-        if (!this.db) {
+        if (!this.em) {
             throw new Error('Database not initialized');
         }
 
-        const save = await this.db.get(
-            'SELECT data FROM project_saves WHERE project_id = ? AND name = ?',
-            [projectId, name]
-        );
+        const save = await this.em.findOne(ProjectSave, {
+            project: projectId,
+            name
+        });
 
-        return save ? (save.data as string) : null;
+        return save ? save.data : null;
     }
 
     async listProjectSaves(projectId: string): Promise<string[]> {
-        if (!this.db) {
+        if (!this.em) {
             throw new Error('Database not initialized');
         }
 
-        const saves = await this.db.all(
-            'SELECT name FROM project_saves WHERE project_id = ? ORDER BY created_at DESC',
-            [projectId]
-        );
+        const saves = await this.em.find(ProjectSave, { project: projectId }, {
+            orderBy: { createdAt: 'DESC' }
+        });
 
-        return saves.map(save => save.name as string);
+        return saves.map(save => save.name);
     }
 }
 

--- a/apps/backend/src/services/DatabaseService.ts
+++ b/apps/backend/src/services/DatabaseService.ts
@@ -190,6 +190,15 @@ class DatabaseService {
 
         return saves.map(save => save.name);
     }
+
+    async getAllProjectSaves(): Promise<number> {
+        if (!this.em) {
+            throw new Error('Database not initialized');
+        }
+
+        const count = await this.em.count(ProjectSave);
+        return count;
+    }
 }
 
 export const dbService = new DatabaseService();

--- a/apps/backend/src/services/GitService.ts
+++ b/apps/backend/src/services/GitService.ts
@@ -32,7 +32,19 @@ export class GitService {
 
     async createTag(projectPath: string, tagName: string): Promise<void> {
         await this.git.cwd(projectPath);
-        await this.git.addTag(tagName);
+        try {
+            // Try to delete the tag if it exists
+            try {
+                await this.git.tag(['-d', tagName]);
+            } catch (error) {
+                // Tag doesn't exist, that's fine
+            }
+            // Create the new tag
+            await this.git.addTag(tagName);
+        } catch (error) {
+            console.error('Failed to create tag:', error);
+            throw error;
+        }
     }
 
     async checkoutTag(projectPath: string, tagName: string): Promise<void> {

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,19 +1,26 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["es2020"],
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
-    "esModuleInterop": true,
+    "baseUrl": "./",
+    "incremental": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "baseUrl": ".",
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": false,
     "paths": {
-      "*": ["node_modules/*"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["src/**/*"],

--- a/apps/web/src/app/project-info/page.tsx
+++ b/apps/web/src/app/project-info/page.tsx
@@ -333,9 +333,9 @@ export default function ProjectPage() {
             <div className="flex gap-2">
               <button
                 onClick={() => setIsSaveDialogOpen(true)}
-                disabled={!isGitRepo || isLoading}
+                disabled={!projectPath || isLoading}
                 className={`flex-1 px-3 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 text-sm ${
-                  (!isGitRepo || isLoading) ? 'opacity-50 cursor-not-allowed' : ''
+                  (!projectPath || isLoading) ? 'opacity-50 cursor-not-allowed' : ''
                 }`}
               >
                 Save State

--- a/apps/web/src/app/project-info/page.tsx
+++ b/apps/web/src/app/project-info/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { ChatMessage, ProjectDetails } from "@/types/api";
-import { apiClient } from "@/services/api";
-import { DirectoryBrowser } from "@/components/DirectoryBrowser";
-import { ConfirmDialog } from "@/components/ConfirmDialog";
-import { Dialog } from "@/components/Dialog";
+import { ChatMessage, ProjectDetails } from "../types/api";
+import { apiClient } from "../services/api";
+import { DirectoryBrowser } from "../components/DirectoryBrowser";
+import { ConfirmDialog } from "../components/ConfirmDialog";
+import { Dialog } from "../components/Dialog";
 
 export default function ProjectPage() {
   const [projectId, setProjectId] = useState<string | null>(null);
@@ -31,8 +31,22 @@ export default function ProjectPage() {
   const [isLoadDialogOpen, setIsLoadDialogOpen] = useState(false);
   const [saveName, setSaveName] = useState("");
   const [savedStates, setSavedStates] = useState<string[]>([]);
+  const [totalSavedProjects, setTotalSavedProjects] = useState(0);
   const chatInputRef = useRef<HTMLInputElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Load total saved projects when component mounts
+  useEffect(() => {
+    const loadTotalSavedProjects = async () => {
+      try {
+        const count = await apiClient.getTotalSavedProjects();
+        setTotalSavedProjects(count);
+      } catch (error) {
+        console.error('Failed to get total saved projects:', error);
+      }
+    };
+    loadTotalSavedProjects();
+  }, []);
 
   // Auto-scroll to bottom when messages change
   const scrollToBottom = () => {
@@ -187,6 +201,8 @@ export default function ProjectPage() {
     try {
       await apiClient.saveProjectState(projectId, saveName);
       await loadSavedStates();
+      const count = await apiClient.getTotalSavedProjects();
+      setTotalSavedProjects(count);
       setIsSaveDialogOpen(false);
       setSaveName("");
     } catch (error) {
@@ -350,12 +366,12 @@ export default function ProjectPage() {
               </button>
               <button
                 onClick={() => setIsLoadDialogOpen(true)}
-                disabled={isLoading || savedStates.length === 0}
+                disabled={isLoading || totalSavedProjects === 0}
                 className={`flex-1 px-3 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 text-sm ${
-                  (isLoading || savedStates.length === 0) ? 'opacity-50 cursor-not-allowed' : ''
+                  (isLoading || totalSavedProjects === 0) ? 'opacity-50 cursor-not-allowed' : ''
                 }`}
               >
-                Load State ({savedStates.length})
+                Load State ({totalSavedProjects})
               </button>
             </div>
           </div>

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -1,4 +1,4 @@
-import { ApiClient, ChatResponse, Project } from '@/types/api';
+import { ApiClient, ChatResponse, Project } from '../types/api';
 
 class ApiClientImpl implements ApiClient {
     private baseUrl: string;
@@ -85,6 +85,11 @@ class ApiClientImpl implements ApiClient {
 
     async listProjectSaves(projectId: string): Promise<string[]> {
         return this.request<string[]>(`/projects/${projectId}/saves`);
+    }
+
+    async getTotalSavedProjects(): Promise<number> {
+        const response = await this.request<{ count: number }>('/projects/saves/count');
+        return response.count;
     }
 }
 

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -48,4 +48,5 @@ export interface ApiClient {
     saveProjectState(projectId: string, saveName: string): Promise<void>;
     loadProjectState(projectId: string, saveName: string): Promise<Project>;
     listProjectSaves(projectId: string): Promise<string[]>;
+    getTotalSavedProjects(): Promise<number>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,18 @@ importers:
 
   apps/backend:
     dependencies:
+      '@mikro-orm/cli':
+        specifier: ^6.4.0
+        version: 6.4.0(better-sqlite3@11.6.0)(sqlite3@5.1.7)
+      '@mikro-orm/core':
+        specifier: ^6.4.0
+        version: 6.4.0
+      '@mikro-orm/migrations':
+        specifier: ^6.4.0
+        version: 6.4.0(@mikro-orm/core@6.4.0)(@types/node@20.17.9)(better-sqlite3@11.6.0)(sqlite3@5.1.7)
+      '@mikro-orm/sqlite':
+        specifier: ^6.4.0
+        version: 6.4.0(@mikro-orm/core@6.4.0)(better-sqlite3@11.6.0)
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.12
@@ -324,6 +336,9 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@jercle/yargonaut@1.1.5':
+    resolution: {integrity: sha512-zBp2myVvBHp1UaJsNTyS6q4UDKT7eRiqTS4oNTS6VQMd6mpxYOdbeK4pY279cDCdakGy6hG0J3ejoXZVsPwHqw==}
+
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
     engines: {node: '>=6.0.0'}
@@ -353,6 +368,43 @@ packages:
 
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
+  '@mikro-orm/cli@6.4.0':
+    resolution: {integrity: sha512-Jh7/sNK7TRrPvC6APHzCSaJjcLsqOnDyhNQ47xk4D2d9iEYXtAEFMuXOUdHG+XngPL4O7jeivnVAxO9t6VJLlA==}
+    engines: {node: '>= 18.12.0'}
+    hasBin: true
+
+  '@mikro-orm/core@6.4.0':
+    resolution: {integrity: sha512-8DOqA4UXRfo9+mmIepxNioTkWKmn06M0YRLb2jRrVb2NYMsA/ihGaTggbaLQXXLpy/Qk2Ke3+T0mWDyXZKcwnQ==}
+    engines: {node: '>= 18.12.0'}
+
+  '@mikro-orm/knex@6.4.0':
+    resolution: {integrity: sha512-27ZC0RxZ4rcGKam/bJsqgyrjfonCstNAFcdOrs/yncYjV8sGOHSdSxtfWuWQVzQCMEL64K7q+RDCUmygAoo4SA==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^6.0.0
+      better-sqlite3: '*'
+      libsql: '*'
+      mariadb: '*'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      libsql:
+        optional: true
+      mariadb:
+        optional: true
+
+  '@mikro-orm/migrations@6.4.0':
+    resolution: {integrity: sha512-MarHxCmTZbDoG/Ipn9N/+2789R5KYDg8iX3w1Hc2WZT4vM3pKYErdsfx6CUWD0SZhAcAprM7T2MTk3SgnsfPgQ==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^6.0.0
+
+  '@mikro-orm/sqlite@6.4.0':
+    resolution: {integrity: sha512-wU6Yy2tdS7MBdAfAjcpQHctshb4LGz2J3zQLvo8iGebkB+9oRoend1O9jLRvqY6T0jvuew6V0xUZKIKUpkZ3UQ==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^6.0.0
 
   '@monaco-editor/loader@1.4.0':
     resolution: {integrity: sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==}
@@ -454,6 +506,25 @@ packages:
   '@rushstack/eslint-patch@1.10.4':
     resolution: {integrity: sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==}
 
+  '@rushstack/node-core-library@5.10.0':
+    resolution: {integrity: sha512-2pPLCuS/3x7DCd7liZkqOewGM0OzLyCacdvOe8j6Yrx9LkETGnxul1t7603bIaB8nUAooORcct9fFDOQMbWAgw==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/terminal@0.14.3':
+    resolution: {integrity: sha512-csXbZsAdab/v8DbU1sz7WC2aNaKArcdS/FPmXMOXEj/JBBZMvDK0+1b4Qao0kkG0ciB1Qe86/Mb68GjH6/TnMw==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/ts-command-line@4.23.1':
+    resolution: {integrity: sha512-40jTmYoiu/xlIpkkRsVfENtBq4CW3R4azbL0Vmda+fMwHWqss6wwf/Cy/UJmMqIzpfYc2OTnjYP1ZLD3CmyeCA==}
+
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
@@ -478,6 +549,9 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/argparse@1.0.38':
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
   '@types/better-sqlite3@7.6.12':
     resolution: {integrity: sha512-fnQmj8lELIj7BSrZQAdBMHEHX8OZLYIHXqAKT1O7tDfLxaINzf00PMjw22r3N/xXh0w/sGHlO6SVaCQ2mj78lg==}
@@ -682,8 +756,27 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.13.0:
+    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -721,6 +814,9 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -923,6 +1019,9 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  colorette@2.0.19:
+    resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -932,6 +1031,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1005,6 +1108,9 @@ packages:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
 
+  dataloader@2.2.2:
+    resolution: {integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==}
+
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
@@ -1019,6 +1125,15 @@ packages:
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -1104,6 +1219,10 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
+
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
@@ -1113,6 +1232,10 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1279,9 +1402,18 @@ packages:
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
+  esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
+
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
@@ -1344,6 +1476,11 @@ packages:
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
 
+  figlet@1.8.0:
+    resolution: {integrity: sha512-chzvGjd+Sp7KUvPHZv6EXV5Ir3Q7kYNpCr4aHrRW79qFtTefmQZNny+W1pW9kf5zeE6dikku2W50W/wAH2xWgw==}
+    engines: {node: '>= 0.4.0'}
+    hasBin: true
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -1403,6 +1540,14 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs-extra@11.2.0:
+    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
   fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
@@ -1438,12 +1583,19 @@ packages:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
 
+  get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+
   get-symbol-description@1.0.2:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
     engines: {node: '>= 0.4'}
 
   get-tsconfig@4.8.1:
     resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
+
+  getopts@2.3.0:
+    resolution: {integrity: sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -1584,6 +1736,10 @@ packages:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
 
+  import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -1611,6 +1767,10 @@ packages:
   internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
+
+  interpret@2.2.0:
+    resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
+    engines: {node: '>= 0.10'}
 
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
@@ -1785,6 +1945,9 @@ packages:
     resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
     hasBin: true
 
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1801,6 +1964,9 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -1808,12 +1974,51 @@ packages:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
 
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  knex@3.1.0:
+    resolution: {integrity: sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==}
+    engines: {node: '>=16'}
+    hasBin: true
+    peerDependencies:
+      better-sqlite3: '*'
+      mysql: '*'
+      mysql2: '*'
+      pg: '*'
+      pg-native: '*'
+      sqlite3: '*'
+      tedious: '*'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      mysql:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      sqlite3:
+        optional: true
+      tedious:
+        optional: true
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -2027,6 +2232,10 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mikro-orm@6.4.0:
+    resolution: {integrity: sha512-dnkvm+xJifwjPEkwipKPpbVEeW7XL3w06yREQiUxGQwcnVowpt+tYFelgr5dnPTpARFNoP5Lc0qTlpWaXVRsxA==}
+    engines: {node: '>= 18.12.0'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -2107,6 +2316,9 @@ packages:
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2272,6 +2484,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parent-require@1.0.0:
+    resolution: {integrity: sha512-2MXDNZC4aXdkkap+rBBMv0lUsfJqvX5/2FiYYnfCnorZt3Pk06/IOR5KeaoghgS2w07MLWgjbsnyaq6PdHn2LQ==}
+    engines: {node: '>= 0.4.0'}
+
   parse-entities@2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
 
@@ -2308,6 +2524,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pg-connection-string@2.6.2:
+    resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2322,6 +2541,10 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  pony-cause@2.1.11:
+    resolution: {integrity: sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==}
+    engines: {node: '>=12.0.0'}
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -2483,6 +2706,13 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  rechoir@0.8.0:
+    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
+    engines: {node: '>= 10.13.0'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
   reflect.getprototypeof@1.0.7:
     resolution: {integrity: sha512-bMvFGIUKlc/eSfXNX+aZ+EL95/EgZzuwA0OBPTbZZDEJw/0AkentjMuM1oiRfwHrshqk4RzdgiTg5CcDalXN5g==}
     engines: {node: '>= 0.4'}
@@ -2513,9 +2743,17 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -2566,6 +2804,11 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.6.3:
@@ -2667,11 +2910,22 @@ packages:
   spawn-command@0.0.2:
     resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
+
+  sqlstring-sqlite@0.1.1:
+    resolution: {integrity: sha512-9CAYUJ0lEUPYJrswqiqdINNSfq3jqWo/bFJ7tufdoNeSK0Fy+d1kFTxjqO9PIqza0Kri+ZtYMfPVf1aZaFOvrQ==}
+    engines: {node: '>= 0.6'}
+
+  sqlstring@2.3.3:
+    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
+    engines: {node: '>= 0.6'}
 
   ssri@8.0.1:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
@@ -2690,6 +2944,10 @@ packages:
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2822,6 +3080,10 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
 
+  tarn@3.0.2:
+    resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
+    engines: {node: '>=8.0.0'}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -2831,6 +3093,10 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tildify@2.0.0:
+    resolution: {integrity: sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==}
+    engines: {node: '>=8'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2883,6 +3149,10 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2896,6 +3166,10 @@ packages:
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+
+  type-fest@4.30.0:
+    resolution: {integrity: sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==}
+    engines: {node: '>=16'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -2921,6 +3195,10 @@ packages:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  umzug@3.8.2:
+    resolution: {integrity: sha512-BEWEF8OJjTYVC56GjELeHl/1XjFejrD7aHzn+HldRJTx+pL1siBrKHZC8n4K/xL3bEzVA9o++qD1tK2CpZu4KA==}
+    engines: {node: '>=12'}
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
@@ -2957,6 +3235,14 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -3249,6 +3535,12 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@jercle/yargonaut@1.1.5':
+    dependencies:
+      chalk: 4.1.2
+      figlet: 1.8.0
+      parent-require: 1.0.0
+
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -3280,6 +3572,91 @@ snapshots:
       - supports-color
 
   '@kwsites/promise-deferred@1.1.1': {}
+
+  '@mikro-orm/cli@6.4.0(better-sqlite3@11.6.0)(sqlite3@5.1.7)':
+    dependencies:
+      '@jercle/yargonaut': 1.1.5
+      '@mikro-orm/core': 6.4.0
+      '@mikro-orm/knex': 6.4.0(@mikro-orm/core@6.4.0)(better-sqlite3@11.6.0)(sqlite3@5.1.7)
+      fs-extra: 11.2.0
+      tsconfig-paths: 4.2.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - better-sqlite3
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/core@6.4.0':
+    dependencies:
+      dataloader: 2.2.2
+      dotenv: 16.4.5
+      esprima: 4.0.1
+      fs-extra: 11.2.0
+      globby: 11.1.0
+      mikro-orm: 6.4.0
+      reflect-metadata: 0.2.2
+
+  '@mikro-orm/knex@6.4.0(@mikro-orm/core@6.4.0)(better-sqlite3@11.6.0)(sqlite3@5.1.7)':
+    dependencies:
+      '@mikro-orm/core': 6.4.0
+      fs-extra: 11.2.0
+      knex: 3.1.0(better-sqlite3@11.6.0)(sqlite3@5.1.7)
+      sqlstring: 2.3.3
+    optionalDependencies:
+      better-sqlite3: 11.6.0
+    transitivePeerDependencies:
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/migrations@6.4.0(@mikro-orm/core@6.4.0)(@types/node@20.17.9)(better-sqlite3@11.6.0)(sqlite3@5.1.7)':
+    dependencies:
+      '@mikro-orm/core': 6.4.0
+      '@mikro-orm/knex': 6.4.0(@mikro-orm/core@6.4.0)(better-sqlite3@11.6.0)(sqlite3@5.1.7)
+      fs-extra: 11.2.0
+      umzug: 3.8.2(@types/node@20.17.9)
+    transitivePeerDependencies:
+      - '@types/node'
+      - better-sqlite3
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/sqlite@6.4.0(@mikro-orm/core@6.4.0)(better-sqlite3@11.6.0)':
+    dependencies:
+      '@mikro-orm/core': 6.4.0
+      '@mikro-orm/knex': 6.4.0(@mikro-orm/core@6.4.0)(better-sqlite3@11.6.0)(sqlite3@5.1.7)
+      fs-extra: 11.2.0
+      sqlite3: 5.1.7
+      sqlstring-sqlite: 0.1.1
+    transitivePeerDependencies:
+      - better-sqlite3
+      - bluebird
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - supports-color
+      - tedious
 
   '@monaco-editor/loader@1.4.0(monaco-editor@0.52.0)':
     dependencies:
@@ -3356,6 +3733,35 @@ snapshots:
 
   '@rushstack/eslint-patch@1.10.4': {}
 
+  '@rushstack/node-core-library@5.10.0(@types/node@20.17.9)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 7.0.1
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.8
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 20.17.9
+
+  '@rushstack/terminal@0.14.3(@types/node@20.17.9)':
+    dependencies:
+      '@rushstack/node-core-library': 5.10.0(@types/node@20.17.9)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 20.17.9
+
+  '@rushstack/ts-command-line@4.23.1(@types/node@20.17.9)':
+    dependencies:
+      '@rushstack/terminal': 0.14.3(@types/node@20.17.9)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@scarf/scarf@1.4.0': {}
 
   '@swc/counter@0.1.3': {}
@@ -3374,6 +3780,8 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@types/argparse@1.0.38': {}
 
   '@types/better-sqlite3@7.6.12':
     dependencies:
@@ -3627,11 +4035,26 @@ snapshots:
       indent-string: 4.0.0
     optional: true
 
+  ajv-draft-04@1.0.0(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
+
+  ajv-formats@3.0.1(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ajv@8.13.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
       uri-js: 4.4.1
 
   ansi-regex@5.0.1: {}
@@ -3663,6 +4086,10 @@ snapshots:
   arg@4.1.3: {}
 
   arg@5.0.2: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -3922,6 +4349,8 @@ snapshots:
       color-string: 1.9.1
     optional: true
 
+  colorette@2.0.19: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -3929,6 +4358,8 @@ snapshots:
   comma-separated-tokens@1.0.8: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@10.0.1: {}
 
   commander@4.1.1: {}
 
@@ -4001,6 +4432,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.1
 
+  dataloader@2.2.2: {}
+
   date-fns@2.30.0:
     dependencies:
       '@babel/runtime': 7.26.0
@@ -4012,6 +4445,10 @@ snapshots:
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
+
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
 
   debug@4.3.7(supports-color@5.5.0):
     dependencies:
@@ -4078,11 +4515,15 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dotenv@16.4.5: {}
+
   dotenv@16.4.7: {}
 
   eastasianwidth@0.2.0: {}
 
   ee-first@1.1.1: {}
+
+  emittery@0.13.1: {}
 
   emoji-regex@8.0.0: {}
 
@@ -4392,11 +4833,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm@3.2.25: {}
+
   espree@9.6.1:
     dependencies:
       acorn: 8.14.0
       acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 3.4.3
+
+  esprima@4.0.1: {}
 
   esquery@1.6.0:
     dependencies:
@@ -4486,6 +4931,8 @@ snapshots:
     dependencies:
       format: 0.2.2
 
+  figlet@1.8.0: {}
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -4551,6 +4998,18 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fs-extra@11.2.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
+  fs-extra@7.0.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
@@ -4593,6 +5052,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
 
+  get-package-type@0.1.0: {}
+
   get-symbol-description@1.0.2:
     dependencies:
       call-bind: 1.0.7
@@ -4602,6 +5063,8 @@ snapshots:
   get-tsconfig@4.8.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  getopts@2.3.0: {}
 
   github-from-package@0.0.0: {}
 
@@ -4783,6 +5246,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-lazy@4.0.0: {}
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0:
@@ -4807,6 +5272,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.0.6
+
+  interpret@2.2.0: {}
 
   ip-address@9.0.5:
     dependencies:
@@ -4974,6 +5441,8 @@ snapshots:
 
   jiti@1.21.6: {}
 
+  jju@1.4.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -4987,11 +5456,25 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  json5@2.2.3: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@6.1.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -5003,6 +5486,28 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  knex@3.1.0(better-sqlite3@11.6.0)(sqlite3@5.1.7):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.21
+      pg-connection-string: 2.6.2
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    optionalDependencies:
+      better-sqlite3: 11.6.0
+      sqlite3: 5.1.7
+    transitivePeerDependencies:
+      - supports-color
 
   language-subtag-registry@0.3.23: {}
 
@@ -5049,7 +5554,6 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
-    optional: true
 
   make-error@1.3.6: {}
 
@@ -5435,6 +5939,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mikro-orm@6.4.0: {}
+
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
@@ -5508,6 +6014,8 @@ snapshots:
   monaco-editor@0.52.0: {}
 
   ms@2.0.0: {}
+
+  ms@2.1.2: {}
 
   ms@2.1.3: {}
 
@@ -5701,6 +6209,8 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parent-require@1.0.0: {}
+
   parse-entities@2.0.0:
     dependencies:
       character-entities: 1.2.4
@@ -5740,6 +6250,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pg-connection-string@2.6.2: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -5747,6 +6259,8 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  pony-cause@2.1.11: {}
 
   possible-typed-array-names@1.0.0: {}
 
@@ -5927,6 +6441,12 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  rechoir@0.8.0:
+    dependencies:
+      resolve: 1.22.8
+
+  reflect-metadata@0.2.2: {}
+
   reflect.getprototypeof@1.0.7:
     dependencies:
       call-bind: 1.0.7
@@ -5988,7 +6508,11 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -6041,6 +6565,10 @@ snapshots:
   scheduler@0.25.0-rc-66855b96-20241106: {}
 
   semver@6.3.1: {}
+
+  semver@7.5.4:
+    dependencies:
+      lru-cache: 6.0.0
 
   semver@7.6.3: {}
 
@@ -6192,6 +6720,8 @@ snapshots:
 
   spawn-command@0.0.2: {}
 
+  sprintf-js@1.0.3: {}
+
   sprintf-js@1.1.3:
     optional: true
 
@@ -6207,6 +6737,10 @@ snapshots:
       - bluebird
       - supports-color
 
+  sqlstring-sqlite@0.1.1: {}
+
+  sqlstring@2.3.3: {}
+
   ssri@8.0.1:
     dependencies:
       minipass: 3.3.6
@@ -6219,6 +6753,8 @@ snapshots:
   statuses@2.0.1: {}
 
   streamsearch@1.1.0: {}
+
+  string-argv@0.3.2: {}
 
   string-width@4.2.3:
     dependencies:
@@ -6412,6 +6948,8 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
+  tarn@3.0.2: {}
+
   text-table@0.2.0: {}
 
   thenify-all@1.6.0:
@@ -6421,6 +6959,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  tildify@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6469,6 +7009,12 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
   tslib@2.8.1: {}
 
   tunnel-agent@0.6.0:
@@ -6480,6 +7026,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.20.2: {}
+
+  type-fest@4.30.0: {}
 
   type-is@1.6.18:
     dependencies:
@@ -6520,6 +7068,16 @@ snapshots:
       reflect.getprototypeof: 1.0.7
 
   typescript@5.7.2: {}
+
+  umzug@3.8.2(@types/node@20.17.9):
+    dependencies:
+      '@rushstack/ts-command-line': 4.23.1(@types/node@20.17.9)
+      emittery: 0.13.1
+      fast-glob: 3.3.2
+      pony-cause: 2.1.11
+      type-fest: 4.30.0
+    transitivePeerDependencies:
+      - '@types/node'
 
   unbox-primitive@1.0.2:
     dependencies:
@@ -6576,6 +7134,10 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
+
+  universalify@0.1.2: {}
+
+  universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
This PR adds functionality to enable the Load State button based on the total number of saved projects in the database.

Changes include:
- Added /saves/count endpoint to get total saved projects
- Added getTotalSavedProjects method to API client
- Updated frontend to check total saved projects count on mount
- Modified Load State button to use total count
- Changed ProjectSave data type from 'json' to 'text'
- Added migration for ProjectSave data type change
- Improved git tag handling

The Load State button is now properly enabled whenever there are saved projects in the database, even after page refresh.